### PR TITLE
Update ExcelReportBuilder.cs

### DIFF
--- a/src/MicroElements.Metadata/Reporting/Excel/ExcelReportBuilder.cs
+++ b/src/MicroElements.Metadata/Reporting/Excel/ExcelReportBuilder.cs
@@ -361,7 +361,8 @@ namespace MicroElements.Reporting.Excel
             {
                 cell.StyleIndex = 1;
 
-                if (propertyRenderer.PropertyType == typeof(LocalTime))
+                book isLocalTime = propertyRenderer.PropertyType == typeof(LocalTime) || propertyRenderer.PropertyType == typeof(LocalTime?);
+                if (isLocalTime)
                 {
                     cell.StyleIndex = 2;
                 }


### PR DESCRIPTION
Fixed incorrect value display format on attempt to report property of `LocalTime?` type.